### PR TITLE
Path converters for software-by-ID routes should be "path" not "str" to

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
-v3.3x.x 2024-10-29 JP
+v3.36.0 2024-10-29 Eric, JP
+  - CTT-237 Change path converter of str to path for glue2 and resource_v4
+  software by ID routes
   - Fix /wh2/glue2/v1/software_full/ bug that wasn't returning info_sideid
 
 v3.35.0 2024-10-17 JP, Andy

--- a/Operations_Warehouse_Django/glue2/urls.py
+++ b/Operations_Warehouse_Django/glue2/urls.py
@@ -62,12 +62,12 @@ urlpatterns = [
 
 # Complex model routes
     path(r'v1/software/', Software_List.as_view(), name='software-list'),
-    path(r'v1/software/ID/<str:id>/', Software_Detail.as_view(), name='software-detail'),
+    path(r'v1/software/ID/<path:id>/', Software_Detail.as_view(), name='software-detail'),
     path(r'v1/software/ResourceID/<str:resourceid>/', Software_Detail.as_view(), name='software-detail-onresource'),
     path(r'v1/software/AppName/<str:appname>/', Software_Detail.as_view(), name='software-detail'),
 
     path(r'v1/software_full/', Software_Full.as_view(), name='software-fulllist'),
-    path(r'v1/software_full/ID/<str:id>/', Software_Full.as_view(), name='software-fulldetail'),
+    path(r'v1/software_full/ID/<path:id>/', Software_Full.as_view(), name='software-fulldetail'),
     path(r'v1/software_full/ResourceID/<str:resourceid>/', Software_Full.as_view(), name='software-fulldetail-onresource'),
     path(r'v1/software_full/AppName/<str:appname>/', Software_Full.as_view(), name='software-fulldetail-byname'),
 

--- a/Operations_Warehouse_Django/resource_v4/urls.py
+++ b/Operations_Warehouse_Django/resource_v4/urls.py
@@ -4,8 +4,8 @@ from .views import *
 
 urlpatterns = [
     path(r'v4/catalog_search/', Catalog_Search.as_view(), name='catalog-search'),
-    path(r'v4/catalog/id/<str:id>/', Catalog_Detail.as_view(), name='catalog-detail'),
-    path(r'v4/local/id/<str:id>/', Local_Detail.as_view(), name='local-detail-globalid'),
+    path(r'v4/catalog/id/<path:id>/', Catalog_Detail.as_view(), name='catalog-detail'),
+    path(r'v4/local/id/<path:id>/', Local_Detail.as_view(), name='local-detail-globalid'),
     path(r'v4/local_search/', Local_Search.as_view(), name='local-search'),
 #    path(r'^provider/id/(?P<id>.+)/$',
 #        Provider_Detail.as_view(), name='provider-detail'),
@@ -13,7 +13,7 @@ urlpatterns = [
 ##        cache_page(60 * 60)(Provider_Search.as_view()), name='provider-search'),
 #        Provider_Search.as_view(), name='provider-search'),
     path(r'v4/resource_types/', cache_page(60 * 60)(Resource_Types_List.as_view()), name='resource-types-list'),
-    path(r'v4/resource/id/<str:id>/', Resource_Detail.as_view(), name='resource-detail'),
+    path(r'v4/resource/id/<path:id>/', Resource_Detail.as_view(), name='resource-detail'),
     path(r'v4/resource_search/', Resource_Search.as_view(), name='resource-search'),
     path(r'v4/resource_esearch/', Resource_ESearch.as_view(), name='resource-esearch'),
     path(r'v4/relations_cache/', Relations_Cache.as_view(), name='relations-cache'),


### PR DESCRIPTION
allow "/" characters in the ID  CTS-237 ATS-11502