### PR TITLE
Integration badges staging eric

### DIFF
--- a/Operations_Warehouse_Django/Operations_Warehouse_Django/settings.py
+++ b/Operations_Warehouse_Django/Operations_Warehouse_Django/settings.py
@@ -357,6 +357,8 @@ if SETTINGS_MODE == 'SERVER':
     CILOGON_CLIENT_KEY = CONF.get('CILOGON_CLIENT_KEY', None)
     CILOGON_CLIENT_SECRET = CONF.get('CILOGON_CLIENT_SECRET', None)
     TOKENAUTH_INTROSPECTION_CACHE_EXPIRATION = CONF.get('TOKENAUTH_INTROSPECTION_CACHE_EXPIRATION', None)
+    # to let us disable authentication for api routes for debugging
+    DISABLE_PERMISSIONS_FOR_DEBUGGING = CONF.get('DISABLE_PERMISSIONS_FOR_DEBUGGING', False)
     #
 #            'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
     REST_FRAMEWORK = {

--- a/Operations_Warehouse_Django/integration_badges/views.py
+++ b/Operations_Warehouse_Django/integration_badges/views.py
@@ -30,7 +30,7 @@ badging_filter = Q(cider_type__in=badging_types) & Q(latest_status__in=badging_s
 
 if hasattr(settings, 'DISABLE_PERMISSIONS_FOR_DEBUGGING'):
     DISABLE_PERMISSIONS_FOR_DEBUGGING = settings.DISABLE_PERMISSIONS_FOR_DEBUGGING
-else
+else:
     DISABLE_PERMISSIONS_FOR_DEBUGGING = False
 
 # _Detail_ includes all fields from a Model

--- a/Operations_Warehouse_Django/integration_badges/views.py
+++ b/Operations_Warehouse_Django/integration_badges/views.py
@@ -26,7 +26,7 @@ badging_types = ('Compute', 'Storage')  # Expand as more roadmaps with badges ar
 badging_statuses = ('coming soon', 'friendly', 'pre-production', 'production', 'post-production')
 badging_filter = Q(cider_type__in=badging_types) & Q(latest_status__in=badging_statuses) & Q(
     project_affiliation__icontains='ACCESS')
-
+PERMISSIONS_OFF_FOR_DEBUGGING = True
 
 # _Detail_ includes all fields from a Model
 # _Full_ includes fields from a model and dependent Models (i.e. roadmap badges, badge tasks, ..)
@@ -191,8 +191,11 @@ class Resource_Full_v1(GenericAPIView):
     '''
     Resource full details, including roadmaps, badges, and badge status
     '''
-    permission_classes = (AllowAny,)
-    # permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
+    if PERMISSIONS_OFF_FOR_DEBUGGING:
+        permission_classes = (AllowAny,)
+    else
+        permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
+
     renderer_classes = (JSONRenderer,)
     serializer_class = Resource_Full_Serializer
 
@@ -215,8 +218,11 @@ class Resource_Roadmap_Enrollments_v1(GenericAPIView):
     '''
     Resource roadmap and roadmap badge enrollments
     '''
-    permission_classes = (AllowAny,)
-    # permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
+    if PERMISSIONS_OFF_FOR_DEBUGGING:
+        permission_classes = (AllowAny,)
+    else
+        permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
+
     renderer_classes = (JSONRenderer,)
     serializer_class = Resource_Enrollments_Serializer
 
@@ -311,8 +317,11 @@ class Resource_Badge_Status_v1(GenericAPIView):
     '''
     Record Badge Status
     '''
-    permission_classes = (AllowAny,)
-    # permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
+    if PERMISSIONS_OFF_FOR_DEBUGGING:
+        permission_classes = (AllowAny,)
+    else
+        permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
+
     renderer_classes = (JSONRenderer,)
     serializer_class = Resource_Workflow_Post_Serializer
 
@@ -380,8 +389,11 @@ class Resource_Badge_Task_Status_v1(GenericAPIView):
     '''
     Record Badge Task Status
     '''
-    permission_classes = (AllowAny,)
-    # permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
+    if PERMISSIONS_OFF_FOR_DEBUGGING:
+        permission_classes = (AllowAny,)
+    else
+        permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
+
     renderer_classes = (JSONRenderer,)
     serializer_class = Resource_Workflow_Post_Serializer
 
@@ -453,8 +465,11 @@ class Resource_Roadmap_Badges_Status_v1(GenericAPIView):
     '''
     Retrieve all or one resource badge(s) and their status
     '''
-    permission_classes = (AllowAny,)
-    # permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
+    if PERMISSIONS_OFF_FOR_DEBUGGING:
+        permission_classes = (AllowAny,)
+    else
+        permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
+
     renderer_classes = (JSONRenderer,)
     serializer_class = Resource_Roadmap_Serializer
 
@@ -526,8 +541,11 @@ class Resource_Roadmap_Badge_Tasks_Status_v1(GenericAPIView):
     Retrieve details of a specific resource, including roadmaps and their badges.
     It also includes the list of badge statuses of the badges that are at least planned.
     '''
-    permission_classes = (AllowAny,)
-    # permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
+    if PERMISSIONS_OFF_FOR_DEBUGGING:
+        permission_classes = (AllowAny,)
+    else
+        permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
+
     renderer_classes = (JSONRenderer,)
     serializer_class = Resource_Roadmap_Serializer
 

--- a/Operations_Warehouse_Django/integration_badges/views.py
+++ b/Operations_Warehouse_Django/integration_badges/views.py
@@ -36,7 +36,7 @@ if hasattr(settings, 'DISABLE_PERMISSIONS_FOR_DEBUGGING'):
     #DISABLE_PERMISSIONS_FOR_DEBUGGING = settings.DISABLE_PERMISSIONS_FOR_DEBUGGING
 else:
     DISABLE_PERMISSIONS_FOR_DEBUGGING = False
-print(f"settings has this value {settings.DISABLE_PERMISSIONS_FOR_DEBUGGING}")
+
 # _Detail_ includes all fields from a Model
 # _Full_ includes fields from a model and dependent Models (i.e. roadmap badges, badge tasks, ..)
 # _Min_ serializers include minimum set of fields

--- a/Operations_Warehouse_Django/integration_badges/views.py
+++ b/Operations_Warehouse_Django/integration_badges/views.py
@@ -7,6 +7,7 @@ from rest_framework.generics import GenericAPIView
 from django.db import transaction
 from django.utils import timezone
 from django.http import HttpResponse
+from django.conf import settings
 from django.db.models import Q
 
 from integration_badges.models import *
@@ -26,7 +27,11 @@ badging_types = ('Compute', 'Storage')  # Expand as more roadmaps with badges ar
 badging_statuses = ('coming soon', 'friendly', 'pre-production', 'production', 'post-production')
 badging_filter = Q(cider_type__in=badging_types) & Q(latest_status__in=badging_statuses) & Q(
     project_affiliation__icontains='ACCESS')
-PERMISSIONS_OFF_FOR_DEBUGGING = True
+
+if hasattr(settings, 'DISABLE_PERMISSIONS_FOR_DEBUGGING'):
+    DISABLE_PERMISSIONS_FOR_DEBUGGING = settings.DISABLE_PERMISSIONS_FOR_DEBUGGING
+else
+    DISABLE_PERMISSIONS_FOR_DEBUGGING = False
 
 # _Detail_ includes all fields from a Model
 # _Full_ includes fields from a model and dependent Models (i.e. roadmap badges, badge tasks, ..)
@@ -191,7 +196,7 @@ class Resource_Full_v1(GenericAPIView):
     '''
     Resource full details, including roadmaps, badges, and badge status
     '''
-    if PERMISSIONS_OFF_FOR_DEBUGGING:
+    if DISABLE_PERMISSIONS_FOR_DEBUGGING:
         permission_classes = (AllowAny,)
     else:
         permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
@@ -218,7 +223,7 @@ class Resource_Roadmap_Enrollments_v1(GenericAPIView):
     '''
     Resource roadmap and roadmap badge enrollments
     '''
-    if PERMISSIONS_OFF_FOR_DEBUGGING:
+    if DISABLE_PERMISSIONS_FOR_DEBUGGING:
         permission_classes = (AllowAny,)
     else:
         permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
@@ -317,7 +322,7 @@ class Resource_Badge_Status_v1(GenericAPIView):
     '''
     Record Badge Status
     '''
-    if PERMISSIONS_OFF_FOR_DEBUGGING:
+    if DISABLE_PERMISSIONS_FOR_DEBUGGING:
         permission_classes = (AllowAny,)
     else:
         permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
@@ -389,7 +394,7 @@ class Resource_Badge_Task_Status_v1(GenericAPIView):
     '''
     Record Badge Task Status
     '''
-    if PERMISSIONS_OFF_FOR_DEBUGGING:
+    if DISABLE_PERMISSIONS_FOR_DEBUGGING:
         permission_classes = (AllowAny,)
     else:
         permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
@@ -465,7 +470,7 @@ class Resource_Roadmap_Badges_Status_v1(GenericAPIView):
     '''
     Retrieve all or one resource badge(s) and their status
     '''
-    if PERMISSIONS_OFF_FOR_DEBUGGING:
+    if DISABLE_PERMISSIONS_FOR_DEBUGGING:
         permission_classes = (AllowAny,)
     else:
         permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
@@ -541,7 +546,7 @@ class Resource_Roadmap_Badge_Tasks_Status_v1(GenericAPIView):
     Retrieve details of a specific resource, including roadmaps and their badges.
     It also includes the list of badge statuses of the badges that are at least planned.
     '''
-    if PERMISSIONS_OFF_FOR_DEBUGGING:
+    if DISABLE_PERMISSIONS_FOR_DEBUGGING:
         permission_classes = (AllowAny,)
     else:
         permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]

--- a/Operations_Warehouse_Django/integration_badges/views.py
+++ b/Operations_Warehouse_Django/integration_badges/views.py
@@ -29,10 +29,14 @@ badging_filter = Q(cider_type__in=badging_types) & Q(latest_status__in=badging_s
     project_affiliation__icontains='ACCESS')
 
 if hasattr(settings, 'DISABLE_PERMISSIONS_FOR_DEBUGGING'):
-    DISABLE_PERMISSIONS_FOR_DEBUGGING = settings.DISABLE_PERMISSIONS_FOR_DEBUGGING
+    if settings.DISABLE_PERMISSIONS_FOR_DEBUGGING == "True":
+        DISABLE_PERMISSIONS_FOR_DEBUGGING = True
+    else:
+        DISABLE_PERMISSIONS_FOR_DEBUGGING = False
+    #DISABLE_PERMISSIONS_FOR_DEBUGGING = settings.DISABLE_PERMISSIONS_FOR_DEBUGGING
 else:
     DISABLE_PERMISSIONS_FOR_DEBUGGING = False
-
+print(f"settings has this value {settings.DISABLE_PERMISSIONS_FOR_DEBUGGING}")
 # _Detail_ includes all fields from a Model
 # _Full_ includes fields from a model and dependent Models (i.e. roadmap badges, badge tasks, ..)
 # _Min_ serializers include minimum set of fields

--- a/Operations_Warehouse_Django/integration_badges/views.py
+++ b/Operations_Warehouse_Django/integration_badges/views.py
@@ -193,7 +193,7 @@ class Resource_Full_v1(GenericAPIView):
     '''
     if PERMISSIONS_OFF_FOR_DEBUGGING:
         permission_classes = (AllowAny,)
-    else
+    else:
         permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
 
     renderer_classes = (JSONRenderer,)
@@ -220,7 +220,7 @@ class Resource_Roadmap_Enrollments_v1(GenericAPIView):
     '''
     if PERMISSIONS_OFF_FOR_DEBUGGING:
         permission_classes = (AllowAny,)
-    else
+    else:
         permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
 
     renderer_classes = (JSONRenderer,)
@@ -319,7 +319,7 @@ class Resource_Badge_Status_v1(GenericAPIView):
     '''
     if PERMISSIONS_OFF_FOR_DEBUGGING:
         permission_classes = (AllowAny,)
-    else
+    else:
         permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
 
     renderer_classes = (JSONRenderer,)
@@ -391,7 +391,7 @@ class Resource_Badge_Task_Status_v1(GenericAPIView):
     '''
     if PERMISSIONS_OFF_FOR_DEBUGGING:
         permission_classes = (AllowAny,)
-    else
+    else:
         permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
 
     renderer_classes = (JSONRenderer,)
@@ -467,7 +467,7 @@ class Resource_Roadmap_Badges_Status_v1(GenericAPIView):
     '''
     if PERMISSIONS_OFF_FOR_DEBUGGING:
         permission_classes = (AllowAny,)
-    else
+    else:
         permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
 
     renderer_classes = (JSONRenderer,)
@@ -543,7 +543,7 @@ class Resource_Roadmap_Badge_Tasks_Status_v1(GenericAPIView):
     '''
     if PERMISSIONS_OFF_FOR_DEBUGGING:
         permission_classes = (AllowAny,)
-    else
+    else:
         permission_classes = [IsCoordinator | (IsAuthenticated & ReadOnly)]
 
     renderer_classes = (JSONRenderer,)


### PR DESCRIPTION
If "DISABLE_PERMISSIONS_FOR_DEBUGGING" is set to "True" in warehouse_api.conf, the integration_badges views that have POST routes will ignore their permission classes and AllowAny.