### PR TITLE
Integration badges staging ebb1

### DIFF
--- a/Operations_Warehouse_Django/integration_badges/views.py
+++ b/Operations_Warehouse_Django/integration_badges/views.py
@@ -1,5 +1,5 @@
 import traceback
-from rest_framework.permissions import IsAuthenticated, ReadOnly, AllowAny
+from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.renderers import JSONRenderer, TemplateHTMLRenderer
 from rest_framework.response import Response
 from rest_framework import permissions, status

--- a/Operations_Warehouse_Django/integration_badges/views.py
+++ b/Operations_Warehouse_Django/integration_badges/views.py
@@ -46,6 +46,7 @@ class Roadmap_Full_v1(GenericAPIView):
     Integration Roadmap(s) and related Badge details View
     '''
     permission_classes = (ReadOnly,)
+    authentication_classes = []
     renderer_classes = (JSONRenderer,)
     serializer_class = Roadmap_Full_Serializer
 
@@ -70,6 +71,7 @@ class Badge_Full_v1(GenericAPIView):
     Integration Badge(s) and pre-requisites
     '''
     permission_classes = (ReadOnly,)
+    authentication_classes = []
     renderer_classes = (JSONRenderer,)
     serializer_class = Badge_Full_Serializer
 
@@ -94,6 +96,7 @@ class Roadmap_Review_v1(GenericAPIView):
     Integration Roadmap Review Details
     '''
     permission_classes = (ReadOnly,)
+    authentication_classes = []
     renderer_classes = (JSONRenderer, TemplateHTMLRenderer)
     serializer_class = Roadmap_Review_Serializer
 
@@ -115,6 +118,7 @@ class Badge_Review_v1(GenericAPIView):
     Badge Review Details
     '''
     permission_classes = (ReadOnly,)
+    authentication_classes = []
     renderer_classes = (JSONRenderer, TemplateHTMLRenderer)
     serializer_class = Badge_Review_Serializer
 
@@ -156,6 +160,7 @@ class Badge_Task_Full_v1(GenericAPIView):
     Retrieve an Integration Task by ID
     '''
     permission_classes = (ReadOnly,)
+    authentication_classes = []
     renderer_classes = (JSONRenderer,)
     serializer_class = Badge_Task_Full_Serializer
 
@@ -180,6 +185,7 @@ class Resources_Eligible_List_v1(GenericAPIView):
     Based only on CiDeR since they may not have enrolled in a roadmap yet
     '''
     permission_classes = (ReadOnly,)
+    authentication_classes = []
     renderer_classes = (JSONRenderer,)
     serializer_class = CiderInfrastructure_Summary_Serializer
 
@@ -622,6 +628,7 @@ class DatabaseFile_v1(GenericAPIView):
     Retrieve tasks of a specific badge.
     '''
     permission_classes = (ReadOnly,)
+    authentication_classes = []
     renderer_classes = (JSONRenderer,)
     serializer_class = DatabaseFile_Serializer
 

--- a/Operations_Warehouse_Django/integration_badges/views.py
+++ b/Operations_Warehouse_Django/integration_badges/views.py
@@ -1,5 +1,5 @@
 import traceback
-from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly, AllowAny
+from rest_framework.permissions import IsAuthenticated, ReadOnly, AllowAny
 from rest_framework.renderers import JSONRenderer, TemplateHTMLRenderer
 from rest_framework.response import Response
 from rest_framework import permissions, status
@@ -45,7 +45,7 @@ class Roadmap_Full_v1(GenericAPIView):
     '''
     Integration Roadmap(s) and related Badge details View
     '''
-    permission_classes = (IsAuthenticatedOrReadOnly,)
+    permission_classes = (ReadOnly,)
     renderer_classes = (JSONRenderer,)
     serializer_class = Roadmap_Full_Serializer
 
@@ -69,7 +69,7 @@ class Badge_Full_v1(GenericAPIView):
     '''
     Integration Badge(s) and pre-requisites
     '''
-    permission_classes = (IsAuthenticatedOrReadOnly,)
+    permission_classes = (ReadOnly,)
     renderer_classes = (JSONRenderer,)
     serializer_class = Badge_Full_Serializer
 
@@ -93,7 +93,7 @@ class Roadmap_Review_v1(GenericAPIView):
     '''
     Integration Roadmap Review Details
     '''
-    permission_classes = (IsAuthenticatedOrReadOnly,)
+    permission_classes = (ReadOnly,)
     renderer_classes = (JSONRenderer, TemplateHTMLRenderer)
     serializer_class = Roadmap_Review_Serializer
 
@@ -114,7 +114,7 @@ class Badge_Review_v1(GenericAPIView):
     '''
     Badge Review Details
     '''
-    permission_classes = (IsAuthenticatedOrReadOnly,)
+    permission_classes = (ReadOnly,)
     renderer_classes = (JSONRenderer, TemplateHTMLRenderer)
     serializer_class = Badge_Review_Serializer
 
@@ -155,7 +155,7 @@ class Badge_Task_Full_v1(GenericAPIView):
     '''
     Retrieve an Integration Task by ID
     '''
-    permission_classes = (IsAuthenticatedOrReadOnly,)
+    permission_classes = (ReadOnly,)
     renderer_classes = (JSONRenderer,)
     serializer_class = Badge_Task_Full_Serializer
 
@@ -179,7 +179,7 @@ class Resources_Eligible_List_v1(GenericAPIView):
     
     Based only on CiDeR since they may not have enrolled in a roadmap yet
     '''
-    permission_classes = (IsAuthenticatedOrReadOnly,)
+    permission_classes = (ReadOnly,)
     renderer_classes = (JSONRenderer,)
     serializer_class = CiderInfrastructure_Summary_Serializer
 
@@ -621,7 +621,7 @@ class DatabaseFile_v1(GenericAPIView):
     '''
     Retrieve tasks of a specific badge.
     '''
-    permission_classes = (IsAuthenticatedOrReadOnly,)
+    permission_classes = (ReadOnly,)
     renderer_classes = (JSONRenderer,)
     serializer_class = DatabaseFile_Serializer
 


### PR DESCRIPTION
This changes the permissions class to ReadOnly (from isAuthenticatedOrReadOnly) for routes for which we do not need authentication.  It also sets the authentication_classes for those routes to an empty list, otherwise the default authentication class (cilogon_tokenauth) will always attempt to process a bearer token if it is given, and the route will return an error instead of a result if that authentication check fails (even though it is set ReadOnly).