### PR TITLE
Expand resoure types, add missing organization_id in a serializer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v3.xx.x 2025-08 navarro
+  - Include missing organization_id in CiderInfrastructure_Summary_Serializer
+  - Expand badging_types with 'Network' and 'Data' resources
+
 v3.60.0 2025-08 jlambertson
   - Installed Django User Admin module from - https://github.com/access-ci-org/Operations_ACCESS_Django_User_Admin
 

--- a/Operations_Warehouse_Django/cider/serializers.py
+++ b/Operations_Warehouse_Django/cider/serializers.py
@@ -18,6 +18,7 @@ class CiderInfrastructure_Summary_Serializer(serializers.ModelSerializer):
     short_name = serializers.SerializerMethodField()
     cider_view_url = serializers.SerializerMethodField()
     cider_data_url = serializers.SerializerMethodField()
+    organization_id = serializers.SerializerMethodField()
     organization_name = serializers.SerializerMethodField()
     organization_url = serializers.SerializerMethodField()
     organization_logo_url = serializers.SerializerMethodField()
@@ -28,12 +29,17 @@ class CiderInfrastructure_Summary_Serializer(serializers.ModelSerializer):
         fields = ('cider_resource_id', 'cider_type', 'info_resourceid', 'project_affiliation',
             'short_name', 'resource_descriptive_name', 'resource_description',
             'latest_status', 'latest_status_begin', 'latest_status_end', 'fixed_status',
-            'organization_name', 'organization_url', 'organization_logo_url',
+            'organization_id', 'organization_name', 'organization_url', 'organization_logo_url',
             'cider_view_url', 'cider_data_url', 'updated_at')
         
     def get_short_name(self, object) -> str:
         try:
             return str(object.other_attributes['short_name']) or None
+        except:
+            return None
+    def get_organization_id(self, object) -> str:
+        try:
+            return object.other_attributes['organizations'][0]['organization_id']
         except:
             return None
     def get_organization_name(self, object) -> str:

--- a/Operations_Warehouse_Django/integration_badges/views.py
+++ b/Operations_Warehouse_Django/integration_badges/views.py
@@ -23,7 +23,7 @@ from .permissions import IsRoadmapMaintainer, IsCoordinator, IsImplementer, Read
 
 log = logging.getLogger(__name__)
 
-badging_types = ('Compute', 'Storage')  # Expand as more roadmaps with badges are rolled out
+badging_types = ('Compute', 'Storage', 'Network', 'Data')  # Expand as more roadmaps with badges are rolled out
 badging_statuses = ('coming soon', 'friendly', 'pre-production', 'production', 'post-production')
 badging_filter = Q(cider_type__in=badging_types) & Q(latest_status__in=badging_statuses) & Q(
     project_affiliation__icontains='ACCESS')


### PR DESCRIPTION
New regional network and hosted data collections in badging filter, fix a missing organization_id bug reported by Dinuka