### PR TITLE
enable SOCIAL_ACCOUNT_QUERY_EMAIL to allow auto-account creation

### DIFF
--- a/Operations_Warehouse_Django/Operations_Warehouse_Django/settings.py
+++ b/Operations_Warehouse_Django/Operations_Warehouse_Django/settings.py
@@ -204,6 +204,7 @@ if SETTINGS_MODE == 'SERVER':
     ACCOUNT_LOGOUT_REDIRECT_URL = '/accounts/cilogon/login/'
     LOGIN_URL = '/accounts/cilogon/login/'
     LOGIN_REDIRECT_URL = '/'
+    SOCIALACCOUNT_QUERY_EMAIL = True
 
     INSTALLED_APPS += (
         'corsheaders',


### PR DESCRIPTION
This will enable django to automatically create the django accounts for users who sign in with ACCESS-CI