### PR TITLE
Ctt 919 return resource ids with permissions endpoint

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v3.76.0 2026-03-20 EBB
+ - Change integration_badges/v1/permissions/ to integration_badges/v1/roles/
+ - new endpoint returns a dict of roles for the user
+ - roles dict also includes a list of the Django user permission codenames
+
 v3.75.0 2026-03-03 Dinuka
  - Enabling query support on contacts endpoint (CTT-871)
  - Changed the response to an array of {info_resourceid, project_affiliation, organization_id, organization_name,

--- a/Operations_Warehouse_Django/integration_badges/urls.py
+++ b/Operations_Warehouse_Django/integration_badges/urls.py
@@ -71,7 +71,7 @@ urlpatterns = [
      path(r'v1/files/<str:file_id>/',
           DatabaseFile_v1.as_view(), name='database-file-id-v1'),
 
-     path(r'v1/permissions/',
-          User_Permissions_v1.as_view(), name='user-permissions-v1'),
+     path(r'v1/roles/',
+          User_Roles_v1.as_view(), name='user-roles-v1'),
 
 ]

--- a/Operations_Warehouse_Django/integration_badges/views.py
+++ b/Operations_Warehouse_Django/integration_badges/views.py
@@ -1824,7 +1824,19 @@ class User_Permissions_v1(GenericAPIView):
         for role in permsdict.keys():
             if isinstance(permsdict[role], dict):
                 if "info_groupids" in permsdict[role]:
-                    results.append({"permission": role,  "info_groupids": permsdict[role]["info_groupids"]})
+                    #results.append({"permission": role,  "info_groupids": permsdict[role]["info_groupids"]})
+                    #Also create a info_resourceids list
+                    resource_ids_list = []
+                    for info_groupid in permsdict[role]["info_groupids"]:
+                        try:
+                            cidergroup = CiderGroups.objects.filter(info_groupid=info_groupid).first()
+                        except Exception as e:
+                            print(f"No CiderGroup object found for group {info_groupid}")
+                        if isinstance(cidergroup.info_resourceids, list):
+                            resource_ids_list.extend(cidergroup.info_resourceids)
+                        print(f"{resource_ids_list}")
+                    results.append({"permission": role,  "info_groupids": permsdict[role]["info_groupids"], "info_resourceids": resource_ids_list})
+        
             else:
                 results.append({"permission": role})
 

--- a/Operations_Warehouse_Django/integration_badges/views.py
+++ b/Operations_Warehouse_Django/integration_badges/views.py
@@ -1799,7 +1799,7 @@ class User_Roles_v1(GenericAPIView):
             permissionlist.append(perm.codename)
             # idlist.append(perm.id)
 
-        # print(permissionlist)
+        # print(f"permissionlist is {permissionlist}")
         # print(idlist)
 
         # Reformat for presentation
@@ -1833,9 +1833,11 @@ class User_Roles_v1(GenericAPIView):
                             cidergroup = CiderGroups.objects.filter(info_groupid=info_groupid).first()
                         except Exception as e:
                             print(f"No CiderGroup object found for group {info_groupid}")
-                        if isinstance(cidergroup.info_resourceids, list):
+                        if cidergroup is None:
+                            print(f"info_groupid {info_groupid} has no cidergroup object")
+                        if cidergroup is not None and isinstance(cidergroup.info_resourceids, list):
                             resource_ids_list.extend(cidergroup.info_resourceids)
-                        print(f"{resource_ids_list}")
+                        # print(f"{resource_ids_list}")
                     results.append({"role": role,  "info_groupids": permsdict[role]["info_groupids"], "info_resourceids": resource_ids_list, "permissions": permsdict[role]["permissions"]})
         
             else:

--- a/Operations_Warehouse_Django/integration_badges/views.py
+++ b/Operations_Warehouse_Django/integration_badges/views.py
@@ -1765,9 +1765,9 @@ def get_image_content_file_from_base64(base64_image_string, file_name):
         raise ValueError(f"Error processing image data: {str(e)}")
 
 
-class User_Permissions_v1(GenericAPIView):
+class User_Roles_v1(GenericAPIView):
     """
-    All permissions held by the requesting user
+    All roles (permissions) held by the requesting user
     """
 
     if DISABLE_PERMISSIONS_FOR_DEBUGGING:
@@ -1813,13 +1813,14 @@ class User_Permissions_v1(GenericAPIView):
             if parsedperm[2]:
                 # This is a resource specific permission
                 if not parsedperm[0] in permsdict:
-                    groupid_dict = {"info_groupids": [parsedperm[2]]}
+                    groupid_dict = {"info_groupids": [parsedperm[2]], "permissions": [rawperm]}
                     permsdict[parsedperm[0]] = groupid_dict
                 else:
                     permsdict[parsedperm[0]]["info_groupids"].append(parsedperm[2])
+                    permsdict[parsedperm[0]]["permissions"].append(rawperm)
             else:
                 # This is a non-resource specific permission
-                permsdict[parsedperm[0]] = True
+                permsdict[parsedperm[0]] = rawperm
         #convert permsdict into a list of permissions dicts by role
         for role in permsdict.keys():
             if isinstance(permsdict[role], dict):
@@ -1835,9 +1836,12 @@ class User_Permissions_v1(GenericAPIView):
                         if isinstance(cidergroup.info_resourceids, list):
                             resource_ids_list.extend(cidergroup.info_resourceids)
                         print(f"{resource_ids_list}")
-                    results.append({"permission": role,  "info_groupids": permsdict[role]["info_groupids"], "info_resourceids": resource_ids_list})
+                    results.append({"role": role,  "info_groupids": permsdict[role]["info_groupids"], "info_resourceids": resource_ids_list, "permissions": permsdict[role]["permissions"]})
         
             else:
-                results.append({"permission": role})
+                # results.append({"role": role,"permissions": permsdict[role]})
+                # Not really worth putting the permission codename in for these
+                # but if we change our minds, use the commented out line above
+                results.append({"role": role})
 
-        return MyAPIResponse({"results": {"permissions": results}})
+        return MyAPIResponse({"results": {"roles": results}})


### PR DESCRIPTION
This PR changes integration_badges/v1/permissions/ to integration_badges/v1/roles/
returns results like:
``{
  "results": {
    "roles": [
      {
        "role": "coordinator",
        "info_groupids": [
          "cloudbank.access-ci.org",
          "darwin.udel.access-ci.org",
          "expanse.sdsc.access-ci.org",
          "hive.gatech.access-ci.org"
        ],
        "info_resourceids": [
          "cloudbank.access-ci.org",
          "cloudbank-classroom.access-ci.org",
          "expanse.sdsc.access-ci.org",
          "expanse-gpu.sdsc.access-ci.org",
          "expanse-ps.sdsc.access-ci.org",
          "expanse-air.sdsc.access-ci.org",
          "hive.gatech.access-ci.org"
        ],
        "permissions": [
          "coordinator_cloudbank.access-ci.org",
          "coordinator_darwin.udel.access-ci.org",
          "coordinator_expanse.sdsc.access-ci.org",
          "coordinator_hive.gatech.access-ci.org"
        ]
      },
      {
        "role": "implementer",
        "info_groupids": [
          "osn.osn.access-ci.org"
        ],
        "info_resourceids": [
          "osn.osn.access-ci.org"
        ],
        "permissions": [
          "implementer_osn.osn.access-ci.org"
        ]
      },
      {
        "role": "badge.maintainer"
      },
      {
        "role": "concierge"
      },
      {
        "role": "roadmap.maintainer"
      }
    ]
  },
  "status_code": 200
}``

per [CTT-919](https://access-ci.atlassian.net/browse/CTT-919)